### PR TITLE
feat: delete_appointment — Tarea 1

### DIFF
--- a/src/core/impl/memory_lifemanager.py
+++ b/src/core/impl/memory_lifemanager.py
@@ -103,6 +103,35 @@ class MemoryLifeManager(AbstractLifeManager):
         """
         return self.appointments.get(str(date), [])
 
+    def delete_appointment(self, date: date, index: int) -> bool:
+        """
+        Elimina una cita por su posición en la lista del día.
+
+        Args:
+            date (date): Día de la cita a eliminar.
+            index (int): Posición 0-based de la cita en la lista del día.
+
+        Returns:
+            bool: ``True`` si la cita fue eliminada correctamente.
+
+        Raises:
+            IndexError: Si ``index`` está fuera del rango de citas del día,
+                        si el día no tiene citas, o si el índice es negativo.
+
+        Complejidad: O(n)
+        """
+        date_str = str(date)
+        citas = self.appointments.get(date_str, [])
+
+        if not citas or index < 0 or index >= len(citas):
+            raise IndexError(
+                f"Índice {index} fuera de rango para el día {date_str} "
+                f"({len(citas)} citas)"
+            )
+
+        self.appointments[date_str].pop(index)
+        return True
+
     def log_habit(self, date: date, habit: str, value: str) -> bool:
         """
         Registra o actualiza el valor de un hábito para un día.


### PR DESCRIPTION
## Tarea 1 — `delete_appointment`

### ¿Qué hace este PR?
Implementa `delete_appointment(date, index)` en `MemoryLifeManager`.

### Cambios
- `src/core/impl/memory_lifemanager.py` — método `delete_appointment` implementado

### Estado previo
- `AbstractLifeManager` ya tenía el método abstracto con docstring ✅
- Tests ya estaban escritos en `tests/test_memory_lifemanager.py` ✅
- `MemoryLifeManager` no tenía implementación → `TypeError` en runtime ❌

### Implementación
```python
def delete_appointment(self, date: date, index: int) -> bool:
    date_str = str(date)
    citas = self.appointments.get(date_str, [])
    if not citas or index < 0 or index >= len(citas):
        raise IndexError(f"Índice {index} fuera de rango...")
    self.appointments[date_str].pop(index)
    return True
```

### Casos cubiertos por tests existentes
- ✅ Elimina cita válida → devuelve `True`
- ✅ Elimina cita correcta cuando hay múltiples
- ✅ `IndexError` con índice fuera de rango
- ✅ `IndexError` con día vacío
- ✅ `IndexError` con índice negativo

### Prerequisito para
- Tarea 3: `feat/json-lifemanager` (hereda este método)
